### PR TITLE
fix: change manifest default vendor to a mocked one to avoid accidentally publishing to VTEX vendor

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "example-payment-auth-app",
-  "vendor": "vtex",
+  "vendor": "example-vendor",
   "version": "1.1.0",
   "title": "Example Payment Authentication App",
   "description": "Example Payment Authentication App",


### PR DESCRIPTION
fix: change manifest default vendor to a mocked one to avoid accidentally publishing to VTEX vendor
